### PR TITLE
Bump up version (tantivy 0.13.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lindera-tantivy"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Minoru Osuka <minoru.osuka@gmail.com>"]
 edition = "2018"
 description = "A Tokenizer for Tantivy, based on Lindera."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ categories = ["text-processing"]
 license = "MIT"
 
 [dependencies]
-lindera = "0.4.1"
-tantivy = "0.12.0"
+lindera = "0.5.1"
+tantivy = "0.13.0"


### PR DESCRIPTION
I tested just after bump deps version, and it worked fine!

Thank you for the awesome lib :D

BREAKING CHANGE:
compatible with tantivy 0.13.0