### PR TITLE
Use tokenizer api crate.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ ko-dic-compress = ["lindera-tokenizer/ko-dic-compress"]
 cc-cedict-compress = ["lindera-tokenizer/cc-cedict-compress"]
 
 [dependencies]
-tantivy = "0.20.2"
+tantivy-tokenizer-api = "0.1.1"
 
 lindera-core = "0.25.0"
 lindera-dictionary = "0.25.0"
@@ -31,6 +31,7 @@ lindera-tokenizer = "0.25.0"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports"] }
+tantivy = "0.20.2"
 
 [[bench]]
 name = "bench"

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,4 +1,4 @@
-use tantivy::tokenizer::{Token, TokenStream};
+use tantivy_tokenizer_api::{Token, TokenStream};
 
 use lindera_tokenizer::token::Token as LToken;
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -1,10 +1,9 @@
-use tantivy::tokenizer::{Token, Tokenizer};
-
 use lindera_core::{
     dictionary::{Dictionary, UserDictionary},
     mode::Mode,
 };
 use lindera_tokenizer::tokenizer::Tokenizer as LTokenizer;
+use tantivy_tokenizer_api::{Token, Tokenizer};
 
 use crate::stream::LinderaTokenStream;
 
@@ -47,7 +46,7 @@ impl Tokenizer for LinderaTokenizer {
     feature = "cc-cedict"
 ))]
 mod tests {
-    use tantivy::tokenizer::{TextAnalyzer, Token};
+    use tantivy_tokenizer_api::{Token, Tokenizer, TokenStream};
 
     use lindera_core::mode::Mode;
     use lindera_dictionary::{load_dictionary_from_config, DictionaryConfig, DictionaryKind};
@@ -61,10 +60,9 @@ mod tests {
             path: None,
         };
         let dictionary = load_dictionary_from_config(dictionary_config).unwrap();
-        let tokenizer = LinderaTokenizer::new(dictionary, None, Mode::Normal);
+        let mut tokenizer = LinderaTokenizer::new(dictionary, None, Mode::Normal);
 
-        let mut analyzer = TextAnalyzer::from(tokenizer);
-        let mut token_stream = analyzer.token_stream(text);
+        let mut token_stream = tokenizer.token_stream(text);
         let mut tokens: Vec<Token> = vec![];
         let mut add_token = |token: &Token| {
             tokens.push(token.clone());
@@ -81,10 +79,9 @@ mod tests {
             path: None,
         };
         let dictionary = load_dictionary_from_config(dictionary_config).unwrap();
-        let tokenizer = LinderaTokenizer::new(dictionary, None, Mode::Normal);
+        let mut tokenizer = LinderaTokenizer::new(dictionary, None, Mode::Normal);
 
-        let mut analyzer = TextAnalyzer::from(tokenizer);
-        let mut token_stream = analyzer.token_stream(text);
+        let mut token_stream = tokenizer.token_stream(text);
         let mut tokens: Vec<Token> = vec![];
         let mut add_token = |token: &Token| {
             tokens.push(token.clone());
@@ -101,10 +98,9 @@ mod tests {
             path: None,
         };
         let dictionary = load_dictionary_from_config(dictionary_config).unwrap();
-        let tokenizer = LinderaTokenizer::new(dictionary, None, Mode::Normal);
+        let mut tokenizer = LinderaTokenizer::new(dictionary, None, Mode::Normal);
 
-        let mut analyzer = TextAnalyzer::from(tokenizer);
-        let mut token_stream = analyzer.token_stream(text);
+        let mut token_stream = tokenizer.token_stream(text);
         let mut tokens: Vec<Token> = vec![];
         let mut add_token = |token: &Token| {
             tokens.push(token.clone());
@@ -121,10 +117,9 @@ mod tests {
             path: None,
         };
         let dictionary = load_dictionary_from_config(dictionary_config).unwrap();
-        let tokenizer = LinderaTokenizer::new(dictionary, None, Mode::Normal);
+        let mut tokenizer = LinderaTokenizer::new(dictionary, None, Mode::Normal);
 
-        let mut analyzer = TextAnalyzer::from(tokenizer);
-        let mut token_stream = analyzer.token_stream(text);
+        let mut token_stream = tokenizer.token_stream(text);
         let mut tokens: Vec<Token> = vec![];
         let mut add_token = |token: &Token| {
             tokens.push(token.clone());

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -46,7 +46,7 @@ impl Tokenizer for LinderaTokenizer {
     feature = "cc-cedict"
 ))]
 mod tests {
-    use tantivy_tokenizer_api::{Token, Tokenizer, TokenStream};
+    use tantivy_tokenizer_api::{Token, TokenStream, Tokenizer};
 
     use lindera_core::mode::Mode;
     use lindera_dictionary::{load_dictionary_from_config, DictionaryConfig, DictionaryKind};


### PR DESCRIPTION
Since 0.20.2, there is the crate `tantivy-tokenizer-api` that should be used for implementing a tokenizer.

This PR fixes that for lindera.

I kept `tantivy` only in dev dependencies, I wanted to remove tantivy dependency totally but it's used in the bench and examples. Ideally, you may want to add a specific cargo file for examples and bench to be able to run tests without tantivy. 